### PR TITLE
(fix) Both links point to qb tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 * Download the framework you need!
 * [Serrulata-Forgery-QB](https://github.com/Serrulata-Studios/serrulata-forgery/tree/qb)
 
-* [Serrulata-Forgery-OX](https://github.com/Serrulata-Studios/serrulata-forgery/tree/qb)
+* [Serrulata-Forgery-OX](https://github.com/Serrulata-Studios/serrulata-forgery/tree/ox)
 
 
 # Installation


### PR DESCRIPTION
**Problem:**

When using the Chrome browser on a Windows Desktop PC, the operator of the human interface device made a sudden left click, as the operator was curious to see the difference between QB and Ox.

Upon the page loading, the link directed the user to the QB tree. The user then created a story, which led to an epic, and after multiple iterations throughout QA, the final and correct edit was made. 

This edit appears to be as optimized as the original version, but alas, there was a rush to release the code before Christmas, due to yuletide events happening around the entire world. This meant that the edit needs to be in production before the first clock hits midnight 12/25.

As the latest code was about to be PR'd, there was an issue with trailing white space which sent it back to the developer. The whitespace has been corrected, and now the department submits this PR to correct this unwanted behavior with README.md.

**Issue Log:**
QA Fail - 12/23/2022 - 05:09PM
QA Fail - 12/23/2022 - 06:23PM
QA Fail - 12/23/2022 - 09:18PM
QA Fail - 12/23/2022 - 12:42PM
QA Fail - 12/23/2022 - 08:35PM
QA Fail - 12/24/2022 - 03:45AM
QA PASS - 12/24/2022 - 03:48AM

**Note:** Has not been tested in staging, rushed to proceed through QA to meet deadline. Approved by Mr. John "Not a Forged ID" Smith.

**_/s_**